### PR TITLE
feat: support BiDi protocol

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/aerokube/selenoid/info"
-	"github.com/docker/docker/api"
 	"log"
 	"net"
 	"net/http"
@@ -18,6 +16,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/aerokube/selenoid/info"
+	"github.com/docker/docker/api"
 
 	ggr "github.com/aerokube/ggr/config"
 	"github.com/aerokube/selenoid/config"
@@ -389,9 +390,10 @@ func handler() http.Handler {
 	root.Handle(paths.VNC, websocket.Handler(vnc))
 	root.HandleFunc(paths.Logs, logs)
 	root.HandleFunc(paths.Video, video)
-	root.HandleFunc(paths.Download, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Fileserver }, "DOWNLOADING_FILE"))
-	root.HandleFunc(paths.Clipboard, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Clipboard }, "CLIPBOARD"))
-	root.HandleFunc(paths.Devtools, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Devtools }, "DEVTOOLS"))
+	root.HandleFunc(paths.Download, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Fileserver }, ReverseProxyOpts{status: "DOWNLOADING_FILE"}))
+	root.HandleFunc(paths.Clipboard, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Clipboard }, ReverseProxyOpts{status: "CLIPBOARD"}))
+	root.HandleFunc(paths.Devtools, reverseProxy(func(sess *session.Session) string { return sess.HostPort.Devtools }, ReverseProxyOpts{status: "DEVTOOLS"}))
+	root.HandleFunc(seleniumPaths.ProxySession, reverseProxy(func(sess *session.Session) string { return sess.HostPort.BiDi }, ReverseProxyOpts{status: "BIDI", useOriginalPath: true}))
 	if enableFileUpload {
 		root.HandleFunc(paths.File, fileUpload)
 	}

--- a/service/docker.go
+++ b/service/docker.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/aerokube/selenoid/info"
-	"github.com/docker/docker/api/types"
 	"log"
 	"net"
 	"net/url"
@@ -13,6 +11,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aerokube/selenoid/info"
+	"github.com/docker/docker/api/types"
 
 	"github.com/aerokube/selenoid/config"
 	"github.com/aerokube/selenoid/session"
@@ -458,6 +459,7 @@ func getHostPort(env Environment, servicePort string, caps session.Caps, stat ty
 	}
 	hp := session.HostPort{
 		Selenium:   fn(servicePort, pc[servicePort]),
+		BiDi:       fn(servicePort, pc[servicePort]),
 		Fileserver: fn(ports.Fileserver, pc[ports.Fileserver]),
 		Clipboard:  fn(ports.Clipboard, pc[ports.Clipboard]),
 		Devtools:   fn(ports.Devtools, pc[ports.Devtools]),

--- a/session/session.go
+++ b/session/session.go
@@ -97,6 +97,7 @@ type HostPort struct {
 	Clipboard  string
 	VNC        string
 	Devtools   string
+	BiDi       string
 }
 
 // Map - session uuid to sessions mapping


### PR DESCRIPTION
### What is done:

Add support of BiDi protocol, which is described here - https://w3c.github.io/webdriver-bidi/. In order to support it I add route `/session` (it's different from `/wd/hub/session`, which is already supported in selenoid) and proxy all requests to browser.

So it works the same as for devtools protocol. Client create session and then establish ws-connection via `ws://selenoid.example.com:4444/devtools/<session-id>`. But for BiDi protocol used - `ws://selenoid.example.com:4444/session/<session-id>`.

### How it works in chrome (without selenoid)

BiDi protocol is already supported in chrome, edge and firefox - https://wpt.fyi/results/webdriver/tests/bidi/browser?label=experimental&label=master&aligned. It means that using w3c BiDi protocol - https://w3c.github.io/webdriver-bidi/ I can connect to browser using  `ws://127.0.0.1:4444/session/session_id`. We can look how it works using these steps:

1) Run chrome in docker:
```
docker pull selenoid/chrome:123.0
docker run -it --rm --privileged -p 4444:4444 -p 5900:5900 -e ENABLE_VNC='true' selenoid/chrome:123.0
```
2) Install webdriverio@latest and use node@18.20.0 (or higher):
```
npm i webdriverio@latest
nvm use 18.20.0
```
3) Run script like this:
```
const { remote } = require('webdriverio');

(async () => {
    const browser = await remote({
        protocol: 'http',
        hostname: '127.0.0.1',
        port: 4444,
        capabilities: { browserName: 'chrome' },
        logLevel: 'debug',
    });

    browser.on('log.entryAdded', (entryAdded) => console.log('LOG FROM BRO CONSOLE:', JSON.stringify(entryAdded, null, 4)));
    await browser.execute(() => console.log('Hello Bidi'));

    await browser.deleteSession();
})();
```

As a result I will see output like this:
```
2025-01-14T13:07:11.470Z INFO webdriver: Register BiDi handler for session with id f38b301d8f74d9374c46108f8fc4b1d7
2025-01-14T13:07:11.471Z INFO webdriver: Connect to webSocketUrl WITH HEADERS ws://127.0.0.1:4444/session/f38b301d8f74d9374c46108f8fc4b1d7
2025-01-14T13:07:11.540Z INFO webdriver: Connected session to Bidi protocol
// ...
```

### How it works with selenoid

The same, but we should specify `path: '/wd/hub`.