### PR TITLE
feat: add '-container-pid' option

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 	limit                    int
 	retryCount               int
 	containerNetwork         string
+	containerPid             string
 	sessions                 = session.NewMap()
 	confPath                 string
 	logConfPath              string
@@ -89,6 +90,7 @@ func init() {
 	flag.Var(&mem, "mem", "Containers memory limit e.g. 128m or 1g")
 	flag.Var(&cpu, "cpu", "Containers cpu limit as float e.g. 0.2 or 1.0")
 	flag.StringVar(&containerNetwork, "container-network", service.DefaultContainerNetwork, "Network to be used for containers")
+	flag.StringVar(&containerPid, "container-pid", "", "PID namespace to use for containers")
 	flag.BoolVar(&captureDriverLogs, "capture-driver-logs", false, "Whether to add driver process logs to Selenoid output")
 	flag.BoolVar(&disablePrivileged, "disable-privileged", false, "Whether to disable privileged container mode")
 	flag.StringVar(&videoOutputDir, "video-output-dir", "video", "Directory to save recorded video to")
@@ -162,6 +164,7 @@ func init() {
 		CPU:                  int64(cpu),
 		Memory:               int64(mem),
 		Network:              containerNetwork,
+		PidMode:              containerPid,
 		StartupTimeout:       serviceStartupTimeout,
 		SessionDeleteTimeout: sessionDeleteTimeout,
 		CaptureDriverLogs:    captureDriverLogs,

--- a/service/docker.go
+++ b/service/docker.go
@@ -142,6 +142,9 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 	if len(d.Service.Sysctl) > 0 {
 		hostConfig.Sysctls = d.Service.Sysctl
 	}
+  if d.Environment.PidMode != "" {
+    hostConfig.PidMode = ctr.PidMode(d.Environment.PidMode)
+  }
 	cl := d.Client
 	env := getEnv(d.ServiceBase, d.Caps)
 	cfg := &ctr.Config{
@@ -526,6 +529,9 @@ func startVideoContainer(ctx context.Context, cl *client.Client, requestId uint6
 		AutoRemove:  true,
 		NetworkMode: ctr.NetworkMode(environ.Network),
 	}
+  if environ.PidMode != "" {
+    hostConfig.PidMode = ctr.PidMode(environ.PidMode)
+  }
 	browserContainerName := getContainerIP(environ.Network, browserContainer)
 	if environ.Network == DefaultContainerNetwork {
 		const defaultBrowserContainerName = "browser"

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ type Environment struct {
 	CPU                  int64
 	Memory               int64
 	Network              string
+	PidMode              string
 	Hostname             string
 	StartupTimeout       time.Duration
 	SessionDeleteTimeout time.Duration


### PR DESCRIPTION
In some rootless runtimes it is possible to launch containers only with the option `--pid host`, so in this PR I add the ability to do it via option `-container-pid`.