### PR TITLE
feat: add '-container-graceful-shutdown' option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golang:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-arc
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.22.5
+          go-version: ~1.23.10
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.22.5
+          go-version: ~1.23.10
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,13 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golang:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-arc
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,13 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-arc
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,13 @@ name: test
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golang:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-arc
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,17 @@ jobs:
   golang:
     runs-on: self-hosted-arc
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ~1.22.5
+          go-version: ~1.23.10
 
-      - uses: actions/cache@v3
+      - name: Install GCC
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -31,6 +34,6 @@ jobs:
       - name: Build
         run: ci/build.sh
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           flags: go

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 export GO111MODULE="on"
-go test -tags 's3 metadata' -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg github.com/aerokube/selenoid,github.com/aerokube/selenoid/session,github.com/aerokube/selenoid/config,github.com/aerokube/selenoid/protect,github.com/aerokube/selenoid/service,github.com/aerokube/selenoid/upload,github.com/aerokube/selenoid/info,github.com/aerokube/selenoid/jsonerror
+CGO_ENABLED=1 go test -tags 's3 metadata' -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg github.com/aerokube/selenoid,github.com/aerokube/selenoid/session,github.com/aerokube/selenoid/config,github.com/aerokube/selenoid/protect,github.com/aerokube/selenoid/service,github.com/aerokube/selenoid/upload,github.com/aerokube/selenoid/info,github.com/aerokube/selenoid/jsonerror
 
 go install golang.org/x/vuln/cmd/govulncheck@latest
 "$(go env GOPATH)"/bin/govulncheck -tags production ./...

--- a/docs/log-files.adoc
+++ b/docs/log-files.adoc
@@ -59,6 +59,7 @@ The following statuses are available:
 | DEVTOOLS_SESSION_CLOSED | Sending devtools traffic was stopped
 | DOWNLOADING_FILE | User requested to download file from browser container
 | ENVIRONMENT_NOT_AVAILABLE | Browser with desired name and version does not exist
+| FAILED_TO_STOP_CONTAINER | Failed to stop Docker container
 | FAILED_TO_REMOVE_CONTAINER | Failed to remove Docker container
 | FAILED_TO_TERMINATE_PROCESS | An error occurred while terminating driver process
 | INIT | Server is starting

--- a/main.go
+++ b/main.go
@@ -33,35 +33,36 @@ import (
 )
 
 var (
-	hostname                 string
-	disableDocker            bool
-	disableQueue             bool
-	enableFileUpload         bool
-	listen                   string
-	timeout                  time.Duration
-	maxTimeout               time.Duration
-	newSessionAttemptTimeout time.Duration
-	sessionDeleteTimeout     time.Duration
-	serviceStartupTimeout    time.Duration
-	gracefulPeriod           time.Duration
-	limit                    int
-	retryCount               int
-	containerNetwork         string
-	containerPid             string
-	sessions                 = session.NewMap()
-	confPath                 string
-	logConfPath              string
-	captureDriverLogs        bool
-	disablePrivileged        bool
-	videoOutputDir           string
-	videoRecorderImage       string
-	logOutputDir             string
-	saveAllLogs              bool
-	ggrHost                  *ggr.Host
-	conf                     *config.Config
-	queue                    *protect.Queue
-	manager                  service.Manager
-	cli                      *client.Client
+	hostname                  string
+	disableDocker             bool
+	disableQueue              bool
+	enableFileUpload          bool
+	listen                    string
+	timeout                   time.Duration
+	maxTimeout                time.Duration
+	newSessionAttemptTimeout  time.Duration
+	sessionDeleteTimeout      time.Duration
+	serviceStartupTimeout     time.Duration
+	gracefulPeriod            time.Duration
+	limit                     int
+	retryCount                int
+	containerNetwork          string
+	containerPid              string
+	containerGracefulShutdown bool
+	sessions                  = session.NewMap()
+	confPath                  string
+	logConfPath               string
+	captureDriverLogs         bool
+	disablePrivileged         bool
+	videoOutputDir            string
+	videoRecorderImage        string
+	logOutputDir              string
+	saveAllLogs               bool
+	ggrHost                   *ggr.Host
+	conf                      *config.Config
+	queue                     *protect.Queue
+	manager                   service.Manager
+	cli                       *client.Client
 
 	startTime = time.Now()
 
@@ -91,6 +92,7 @@ func init() {
 	flag.Var(&cpu, "cpu", "Containers cpu limit as float e.g. 0.2 or 1.0")
 	flag.StringVar(&containerNetwork, "container-network", service.DefaultContainerNetwork, "Network to be used for containers")
 	flag.StringVar(&containerPid, "container-pid", "", "PID namespace to use for containers")
+	flag.BoolVar(&containerGracefulShutdown, "container-graceful-shutdown", false, "Terminate containers gracefully with SIGTERM signal")
 	flag.BoolVar(&captureDriverLogs, "capture-driver-logs", false, "Whether to add driver process logs to Selenoid output")
 	flag.BoolVar(&disablePrivileged, "disable-privileged", false, "Whether to disable privileged container mode")
 	flag.StringVar(&videoOutputDir, "video-output-dir", "video", "Directory to save recorded video to")
@@ -165,6 +167,7 @@ func init() {
 		Memory:               int64(mem),
 		Network:              containerNetwork,
 		PidMode:              containerPid,
+		GracefulShutdown:     containerGracefulShutdown,
 		StartupTimeout:       serviceStartupTimeout,
 		SessionDeleteTimeout: sessionDeleteTimeout,
 		CaptureDriverLogs:    captureDriverLogs,

--- a/service/docker.go
+++ b/service/docker.go
@@ -142,9 +142,9 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 	if len(d.Service.Sysctl) > 0 {
 		hostConfig.Sysctls = d.Service.Sysctl
 	}
-  if d.Environment.PidMode != "" {
-    hostConfig.PidMode = ctr.PidMode(d.Environment.PidMode)
-  }
+	if d.Environment.PidMode != "" {
+		hostConfig.PidMode = ctr.PidMode(d.Environment.PidMode)
+	}
 	cl := d.Client
 	env := getEnv(d.ServiceBase, d.Caps)
 	cfg := &ctr.Config{
@@ -170,7 +170,7 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 	log.Printf("[%d] [STARTING_CONTAINER] [%s] [%s]", requestId, image, browserContainerId)
 	err = cl.ContainerStart(ctx, browserContainerId, ctr.StartOptions{})
 	if err != nil {
-		removeContainer(ctx, cl, requestId, browserContainerId)
+		removeContainer(ctx, cl, requestId, browserContainerId, d.Environment)
 		return nil, fmt.Errorf("start container: %v", err)
 	}
 	log.Printf("[%d] [CONTAINER_STARTED] [%s] [%s] [%.2fs]", requestId, image, browserContainerId, info.SecondsSince(browserContainerStartTime))
@@ -186,12 +186,12 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 
 	stat, err := cl.ContainerInspect(ctx, browserContainerId)
 	if err != nil {
-		removeContainer(ctx, cl, requestId, browserContainerId)
+		removeContainer(ctx, cl, requestId, browserContainerId, d.Environment)
 		return nil, fmt.Errorf("inspect container %s: %s", browserContainerId, err)
 	}
 	// _, ok := stat.NetworkSettings.Ports[selenium]
 	// if !ok {
-	// 	removeContainer(ctx, cl, requestId, browserContainerId)
+	// 	removeContainer(ctx, cl, requestId, browserContainerId, d.Environment)
 	// 	return nil, fmt.Errorf("no bindings available for %v", selenium)
 	// }
 	servicePort := d.Service.Port
@@ -218,7 +218,7 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 		if videoContainerId != "" {
 			stopVideoContainer(ctx, cl, requestId, videoContainerId, d.Environment)
 		}
-		removeContainer(ctx, cl, requestId, browserContainerId)
+		removeContainer(ctx, cl, requestId, browserContainerId, d.Environment)
 		return nil, fmt.Errorf("wait: %v", err)
 	}
 	log.Printf("[%d] [SERVICE_STARTED] [%s] [%s] [%.2fs]", requestId, image, browserContainerId, info.SecondsSince(serviceStartTime))
@@ -247,7 +247,7 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 			if videoContainerId != "" {
 				stopVideoContainer(ctx, cl, requestId, videoContainerId, d.Environment)
 			}
-			defer removeContainer(ctx, cl, requestId, browserContainerId)
+			defer removeContainer(ctx, cl, requestId, browserContainerId, d.Environment)
 			if d.LogOutputDir != "" && (d.SaveAllLogs || d.Log) {
 				r, err := d.Client.ContainerLogs(ctx, browserContainerId, ctr.LogsOptions{
 					Timestamps: true,
@@ -529,9 +529,9 @@ func startVideoContainer(ctx context.Context, cl *client.Client, requestId uint6
 		AutoRemove:  true,
 		NetworkMode: ctr.NetworkMode(environ.Network),
 	}
-  if environ.PidMode != "" {
-    hostConfig.PidMode = ctr.PidMode(environ.PidMode)
-  }
+	if environ.PidMode != "" {
+		hostConfig.PidMode = ctr.PidMode(environ.PidMode)
+	}
 	browserContainerName := getContainerIP(environ.Network, browserContainer)
 	if environ.Network == DefaultContainerNetwork {
 		const defaultBrowserContainerName = "browser"
@@ -548,7 +548,7 @@ func startVideoContainer(ctx context.Context, cl *client.Client, requestId uint6
 		hostConfig,
 		&network.NetworkingConfig{}, nil, "")
 	if err != nil {
-		removeContainer(ctx, cl, requestId, browserContainer.ID)
+		removeContainer(ctx, cl, requestId, browserContainer.ID, environ)
 		return "", fmt.Errorf("create video container: %v", err)
 	}
 
@@ -556,8 +556,8 @@ func startVideoContainer(ctx context.Context, cl *client.Client, requestId uint6
 	log.Printf("[%d] [STARTING_VIDEO_CONTAINER] [%s] [%s]", requestId, videoContainerImage, videoContainerId)
 	err = cl.ContainerStart(ctx, videoContainerId, ctr.StartOptions{})
 	if err != nil {
-		removeContainer(ctx, cl, requestId, browserContainer.ID)
-		removeContainer(ctx, cl, requestId, videoContainerId)
+		removeContainer(ctx, cl, requestId, browserContainer.ID, environ)
+		removeContainer(ctx, cl, requestId, videoContainerId, environ)
 		return "", fmt.Errorf("start video container: %v", err)
 	}
 	log.Printf("[%d] [VIDEO_CONTAINER_STARTED] [%s] [%s] [%.2fs]", requestId, videoContainerImage, videoContainerId, info.SecondsSince(videoContainerStartTime))
@@ -583,17 +583,26 @@ func stopVideoContainer(ctx context.Context, cli *client.Client, requestId uint6
 	select {
 	case <-doesNotExist:
 	case <-notRunning:
-		removeContainer(ctx, cli, requestId, containerId)
+		removeContainer(ctx, cli, requestId, containerId, env)
 		return
 	case <-time.After(env.SessionDeleteTimeout):
-		removeContainer(ctx, cli, requestId, containerId)
+		removeContainer(ctx, cli, requestId, containerId, env)
 		return
 	}
 	log.Printf("[%d] [STOPPED_VIDEO_CONTAINER] [%s]", requestId, containerId)
 }
 
-func removeContainer(ctx context.Context, cli *client.Client, requestId uint64, id string) {
+func removeContainer(ctx context.Context, cli *client.Client, requestId uint64, id string, env Environment) {
 	log.Printf("[%d] [REMOVING_CONTAINER] [%s]", requestId, id)
+
+	if env.GracefulShutdown {
+		timeout := 5
+		err := cli.ContainerStop(ctx, id, ctr.StopOptions{Timeout: &timeout})
+		if err != nil {
+			log.Printf("[%d] [FAILED_TO_STOP_CONTAINER] [%s] [%v]", requestId, id, err)
+		}
+	}
+
 	err := cli.ContainerRemove(ctx, id, ctr.RemoveOptions{Force: true, RemoveVolumes: true})
 	if err != nil {
 		log.Printf("[%d] [FAILED_TO_REMOVE_CONTAINER] [%s] [%v]", requestId, id, err)

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,7 @@ type Environment struct {
 	Memory               int64
 	Network              string
 	PidMode              string
+	GracefulShutdown     bool
 	Hostname             string
 	StartupTimeout       time.Duration
 	SessionDeleteTimeout time.Duration


### PR DESCRIPTION
Add abilityty to specify `-container-graceful-shutdown true` in order to correctly terminate containers. Under the hood, it sends sigterm first in order to correctly cleanup resources